### PR TITLE
Implement get_key_references for Hive

### DIFF
--- a/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
@@ -179,7 +179,7 @@ public class SteemJ {
     // ## ACCOUNT BY KEY API ###################################################
     // #########################################################################
 
-    public List<AccountName> getKeyReferences(List<PublicKey> publicKeys)
+    public List<List<AccountName>> getKeyReferences(List<PublicKey> publicKeys)
             throws SteemCommunicationException, SteemResponseException {
         return AccountByKeyApi.getKeyReferences(SteemJ.communicationHandler, new GetKeyReferencesArgs(publicKeys))
                 .getAccounts();

--- a/core/src/main/java/eu/bittrade/libs/steemj/plugins/apis/account/by/key/models/GetKeyReferencesReturn.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/plugins/apis/account/by/key/models/GetKeyReferencesReturn.java
@@ -16,6 +16,7 @@
  */
 package eu.bittrade.libs.steemj.plugins.apis.account.by.key.models;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -32,19 +33,20 @@ import eu.bittrade.libs.steemj.protocol.AccountName;
  */
 public class GetKeyReferencesReturn {
     @JsonProperty("accounts")
-    private List<AccountName> accounts;
+    private List<List<AccountName>> accounts;
 
     /**
      * This object is only used to wrap the JSON response in a POJO, so
      * therefore this class should not be instantiated.
      */
     private GetKeyReferencesReturn() {
+        this.accounts = new ArrayList<>();
     }
 
     /**
      * @return the accounts
      */
-    public List<AccountName> getAccounts() {
+    public List<List<AccountName>> getAccounts() {
         return accounts;
     }
 

--- a/core/src/test/java/eu/bittrade/libs/steemj/plugins/apis/account/by/key/AccountByKeyApiIT.java
+++ b/core/src/test/java/eu/bittrade/libs/steemj/plugins/apis/account/by/key/AccountByKeyApiIT.java
@@ -71,7 +71,7 @@ public class AccountByKeyApiIT extends BaseIT {
     @Category({ IntegrationTest.class })
     @Test
     public void testGetBlock() throws SteemCommunicationException, SteemResponseException {
-        final List<AccountName> accountList = AccountByKeyApi
+        final List<List<AccountName>> accountList = AccountByKeyApi
                 .getKeyReferences(COMMUNICATION_HANDLER,
                         new GetKeyReferencesArgs(
                                 Arrays.asList(new PublicKey("STM79rHgAa75LkJJrhhr4fSM8ccBoLwod3HaAAxzihNRFKZSvTvZ5"))))

--- a/sample/src/main/java/my/sample/project/GetMyHiveData.java
+++ b/sample/src/main/java/my/sample/project/GetMyHiveData.java
@@ -1,4 +1,4 @@
-package my.sample.project;
+package my.sample.project; // Or eu.bittrade.libs.steemj.sample if that's your package
 
 import eu.bittrade.libs.steemj.SteemJ;
 import eu.bittrade.libs.steemj.configuration.SteemJConfig;
@@ -6,11 +6,14 @@ import eu.bittrade.libs.steemj.exceptions.SteemCommunicationException;
 import eu.bittrade.libs.steemj.exceptions.SteemResponseException;
 import eu.bittrade.libs.steemj.protocol.AccountName;
 import eu.bittrade.libs.steemj.plugins.apis.condenser.models.ExtendedAccount;
-// Removed unused imports for now
+import eu.bittrade.libs.steemj.protocol.PublicKey; // Needed for getKeyReferences test
+
+// Unused imports if only testing getAccounts and getKeyReferences
 // import eu.bittrade.libs.steemj.plugins.apis.account.history.models.AppliedOperation;
 // import eu.bittrade.libs.steemj.plugins.apis.database.models.DynamicGlobalProperty;
 // import org.joou.UInteger;
 // import org.joou.ULong;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-// import java.util.Map; // Not needed as account history is commented out
+// import java.util.Map; // Not needed if other tests are commented out
 
 public class GetMyHiveData {
     private static final Logger LOGGER = LoggerFactory.getLogger(GetMyHiveData.class);
@@ -29,13 +32,13 @@ public class GetMyHiveData {
         SteemJConfig myConfig = SteemJConfig.getInstance();
         myConfig.setResponseTimeout(100000); // Set a reasonable timeout
 
-        String hiveNodeHttpUrl = "https://anyx.io"; // Using a different node, with HTTPS
+        String hiveNodeHttpUrl = "https://anyx.io"; // Using a reliable Hive node
         try {
             myConfig.getEndpointURIs().clear(); // Clear existing default URIs
             myConfig.addEndpointURI(new URI(hiveNodeHttpUrl));
             LOGGER.info("Configured endpoint URI: {}", hiveNodeHttpUrl);
 
-            // Explicitly set Hive chain ID - good practice, especially if library might default to Steem
+            // Explicitly set Hive chain ID
             myConfig.setChainId("beeab0de00000000000000000000000000000000000000000000000000000000");
             LOGGER.info("Set Chain ID for Hive.");
 
@@ -55,7 +58,7 @@ public class GetMyHiveData {
             SteemJ steemJ = new SteemJ();
             LOGGER.info("SteemJ instance created.");
 
-            // 3. Fetch Your Account Details - FOCUS ON THIS CALL
+            // 1. Fetch Your Account Details (from previous successful test)
             LOGGER.info("Attempting to fetch account details for: {}", myHiveAccountName.getName());
             List<AccountName> accountsToFetch = new ArrayList<>();
             accountsToFetch.add(myHiveAccountName);
@@ -67,54 +70,75 @@ public class GetMyHiveData {
                 LOGGER.info("Successfully fetched account details:");
                 LOGGER.info("  Name: {}", myAccount.getName().getName());
                 LOGGER.info("  Balance (HIVE): {}", myAccount.getBalance());
-                LOGGER.info("  SBD/HBD Balance: {}", myAccount.getSbdBalance()); // Assuming getSbdBalance for HBD
+                LOGGER.info("  SBD/HBD Balance: {}", myAccount.getSbdBalance()); 
                 LOGGER.info("  Vesting Shares (HP): {}", myAccount.getVestingShares());
-                // You can add more fields from ExtendedAccount like reputation, created, etc.
-                // LOGGER.info("  Reputation: {}", myAccount.getReputation());
-                // LOGGER.info("  Creation Date: {}", myAccount.getCreated());
             } else {
                 LOGGER.warn("Could not retrieve account details for {}.", myHiveAccountName.getName());
             }
 
-            // Temporarily comment out other calls to isolate issues
+
+            // 2. <<< NEW SECTION FOR TESTING getKeyReferences >>>
+            LOGGER.info("--------------------------------------------------------------------");
+            LOGGER.info("Attempting to get key references for a public key...");
+
+            try {
+                // Use one of milk21's actual public keys.
+                // Posting Key for "milk21" (from previous successful getAccounts response):
+                String testPublicKeyString = "STM6oASGgigTTdn7L4jsdVF7jGRMe8avaDAQZMff7spgro6ov8caw"; 
+                // (If "milk21" is not your account, or you want to test a different key, replace this string)
+                
+                PublicKey publicKeyToLookup = new PublicKey(testPublicKeyString);
+
+                List<PublicKey> keysToLookup = new ArrayList<>();
+                keysToLookup.add(publicKeyToLookup);
+
+                LOGGER.info("Looking up accounts for public key: {}", testPublicKeyString);
+
+                // Call the method we updated in SteemJ.java
+                List<List<AccountName>> resultsForKeyReferences = steemJ.getKeyReferences(keysToLookup);
+
+                if (resultsForKeyReferences != null && !resultsForKeyReferences.isEmpty()) {
+                    LOGGER.info("Successfully fetched key references. Result(s):");
+                    for (int i = 0; i < resultsForKeyReferences.size(); i++) {
+                        List<AccountName> accountsForThisKey = resultsForKeyReferences.get(i);
+                        // Use getAddressFromPublicKey() here:
+                        String inputKeyString = (keysToLookup.get(i) != null) ? keysToLookup.get(i).getAddressFromPublicKey() : "N/A";
+                        LOGGER.info("  For key {} (input index {}):", inputKeyString, i);
+                        if (accountsForThisKey != null && !accountsForThisKey.isEmpty()) {
+                            for (AccountName accountNameObj : accountsForThisKey) {
+                                LOGGER.info("    - Found account: {}", accountNameObj.getName());
+                            }
+                        } else {
+                            LOGGER.info("    (No accounts found associated with this specific key)");
+                        }
+                    }
+                } else {
+                    LOGGER.warn("Could not retrieve key references, or the result was empty for key(s): {}", keysToLookup);
+                }
+
+            } catch (SteemCommunicationException | SteemResponseException e) { 
+                LOGGER.error("Error during getKeyReferences call: {}", e.getMessage(), e);
+            } catch (Exception e) { 
+                LOGGER.error("Unexpected error during getKeyReferences test: {}", e.getMessage(), e);
+            }
+            LOGGER.info("--------------------------------------------------------------------");
+            // <<< END OF NEW SECTION for getKeyReferences >>>
+
+
+            // Other tests (account history, global properties) are still commented out
             /*
             // 4. Fetch Your Account History
-            LOGGER.info("Attempting to fetch account history for: {}", myHiveAccountName.getName());
-            Map<UInteger, AppliedOperation> accountHistory = steemJ.getAccountHistory(myHiveAccountName, ULong.valueOf(-1), UInteger.valueOf(10));
-
-            if (accountHistory != null && !accountHistory.isEmpty()) {
-                LOGGER.info("Recent account history (newest first):");
-                accountHistory.entrySet().stream()
-                    .sorted(Map.Entry.<UInteger, AppliedOperation>comparingByKey().reversed())
-                    .forEach(entry -> {
-                        AppliedOperation opDetails = entry.getValue();
-                        LOGGER.info("  Op Index: {}, Timestamp: {}, Type: {}",
-                            entry.getKey(),
-                            opDetails.getTimestamp(),
-                            opDetails.getOp().getClass().getSimpleName()
-                        );
-                    });
-            } else {
-                LOGGER.warn("No account history found for {}.", myHiveAccountName.getName());
-            }
+            // ... (code for account history was here) ...
 
             // 5. (Optional) Fetch Dynamic Global Properties
-            LOGGER.info("Attempting to fetch dynamic global properties...");
-            DynamicGlobalProperty globalProperties = steemJ.getDynamicGlobalProperties();
-            if (globalProperties != null) {
-                LOGGER.info("Current Head Block Number: {}", globalProperties.getHeadBlockNumber());
-                LOGGER.info("Current Time: {}", globalProperties.getTime());
-            } else {
-                LOGGER.warn("Could not retrieve dynamic global properties.");
-            }
+            // ... (code for global properties was here) ...
             */
 
-            LOGGER.info("GetMyHiveData sample finished processing getAccounts.");
+            LOGGER.info("GetMyHiveData sample finished all processing."); // Updated this log message
 
         } catch (SteemCommunicationException e) {
             LOGGER.error("Steem Communication Exception: {} - Node URI used: {}", e.getMessage(), hiveNodeHttpUrl, e);
         } catch (SteemResponseException e) {
-            // Corrected logging for SteemResponseException
             LOGGER.error("Steem Response Exception: {} - Code: {}", e.getMessage(), e.getCode(), e);
         } catch (Exception e) {
             LOGGER.error("An unexpected error occurred: {}", e.getMessage(), e);


### PR DESCRIPTION
This PR implements the `account_by_key_api.get_key_references` endpoint for Hive.

Key changes:
Modified `GetKeyReferencesReturn.java` to correctly deserialize the `List<List<AccountName>>` response structure from Hive, aligning with the API documentation.

Updated `SteemJ.java#getKeyReferences` method to return this `List<List<AccountName>>`.