### PR TITLE
feat(hive): Add Hive compatibility for get_account_history API

### DIFF
--- a/core/src/main/java/eu/bittrade/libs/steemj/base/models/deserializer/AssetDeserializer.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/base/models/deserializer/AssetDeserializer.java
@@ -1,16 +1,17 @@
 /*
  *     This file is part of SteemJ (formerly known as 'Steem-Java-Api-Wrapper')
- * 
+ *
  *     SteemJ is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
+
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     SteemJ is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with SteemJ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,33 +24,54 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import eu.bittrade.libs.steemj.protocol.LegacyAsset;
 import eu.bittrade.libs.steemj.protocol.enums.LegacyAssetSymbolType;
 
 /**
+ * A custom deserializer for LegacyAsset types.
+ * 
+ * This has been updated to handle both the legacy string format (e.g., "1.000 HIVE")
+ * and the modern object format used by Hive (e.g., {"amount":"1000", "precision":3, "nai":"@@000000021"}).
+ * 
  * @author <a href="http://steemit.com/@dez1337">dez1337</a>
+ * @author Your Name Here (for the modifications)
  */
 public class AssetDeserializer extends JsonDeserializer<LegacyAsset> {
     @Override
-    public LegacyAsset deserialize(JsonParser jasonParser, DeserializationContext deserializationContext) throws IOException {
-        JsonToken currentToken = jasonParser.currentToken();
-        if (currentToken != null && JsonToken.VALUE_STRING.equals(currentToken)) {
-            String[] assetFields = jasonParser.getText().split(" ");
+    public LegacyAsset deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonToken currentToken = jp.currentToken();
+
+        // Handle the legacy string format (e.g., "1.234 STEEM").
+        if (JsonToken.VALUE_STRING.equals(currentToken)) {
+            String[] assetFields = jp.getText().split(" ");
 
             if (assetFields.length == 2) {
-                /*
-                 * Set the symbol first which calculates the precision
-                 * internally. internally.
-                 *
-                 * The amount is provided as a double value while we need a long
-                 * value for the byte representation so we transform the amount
-                 * into a long value here.
-                 */
                 return new LegacyAsset(new BigDecimal(assetFields[0]), LegacyAssetSymbolType.valueOf(assetFields[1]));
             }
         }
+        
+        // Handle the modern object format (e.g., { "amount": "1234", "precision": 3, "nai": "..." }).
+        if (JsonToken.START_OBJECT.equals(currentToken)) {
+            JsonNode rootNode = jp.getCodec().readTree(jp);
 
-        throw new IllegalArgumentException("Found '" + currentToken + "' instead of '" + JsonToken.VALUE_STRING + "'.");
+            // Make sure all required fields are present
+            if (rootNode.has("amount") && rootNode.has("precision") && rootNode.has("nai")) {
+                long amount = rootNode.get("amount").asLong();
+                int precision = rootNode.get("precision").asInt();
+                String nai = rootNode.get("nai").asText();
+                
+                LegacyAssetSymbolType symbol = LegacyAssetSymbolType.fromNai(nai, precision);
+                
+                // The amount from the API is a long integer (e.g., 1234 for "1.234").
+                // We need to convert it to a BigDecimal by dividing by 10^precision.
+                BigDecimal realAmount = new BigDecimal(amount).divide(new BigDecimal(Math.pow(10, precision)));
+                
+                return new LegacyAsset(realAmount, symbol);
+            }
+        }
+
+        throw new IllegalArgumentException("Cannot deserialize LegacyAsset: Expected a JSON string or object, but found " + currentToken);
     }
 }

--- a/core/src/main/java/eu/bittrade/libs/steemj/plugins/apis/account/history/models/deserializer/OperationHistoryEntryDeserializer.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/plugins/apis/account/history/models/deserializer/OperationHistoryEntryDeserializer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.AppliedOperation;
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.OperationHistoryEntry;
@@ -19,24 +20,50 @@ import eu.bittrade.libs.steemj.plugins.apis.account.history.models.OperationHist
  * This class is the replacement for the old AppliedOperationHashMapDeserializer.
  *
  * @author <a href="https://github.com/AI-Hive">AI-Hive</a>
+ * @author Your Name Here (for the modifications)
  */
 public class OperationHistoryEntryDeserializer extends JsonDeserializer<OperationHistoryEntry> {
     @Override
     public OperationHistoryEntry deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        JsonNode node = jp.getCodec().readTree(jp);
+        JsonNode rootNode = jp.getCodec().readTree(jp);
 
-        if (!node.isArray() || node.size() != 2) {
+        if (!rootNode.isArray() || rootNode.size() != 2) {
             throw new IOException("Expected a JSON array with two elements [index, operation_object] for OperationHistoryEntry.");
         }
 
         // The first element is the history index number.
-        long historyIndex = node.get(0).asLong();
+        long historyIndex = rootNode.get(0).asLong();
         
         // The second element is the operation object.
-        // We use the parser's codec to deserialize this part of the tree into an AppliedOperation object.
-        AppliedOperation operation = jp.getCodec().treeToValue(node.get(1), AppliedOperation.class);
+        JsonNode operationNode = rootNode.get(1);
+
+        // ### START OF HIVE FIX ###
+        // The Hive API for get_account_history nests the actual operation data
+        // inside a "value" field within the "op" object. We need to restructure this.
+        if (operationNode.has("op") && operationNode.get("op").has("value")) {
+            JsonNode opField = operationNode.get("op");
+            JsonNode valueField = opField.get("value");
+
+            // We need to create a new, flattened JSON object.
+            // Start by copying all fields from the "value" object.
+            ObjectNode newOpNode = (ObjectNode) valueField.deepCopy();
+
+            // The "value" object does not contain the "type", but the parent "op" object does.
+            // We must copy the "type" field from the parent into our new object so that
+            // Jackson's type resolver can work correctly.
+            if (opField.has("type")) {
+                newOpNode.set("type", opField.get("type"));
+            }
+
+            // Now, we replace the original "op" field in the main operation object
+            // with our newly created, flattened "op" field.
+            ((ObjectNode) operationNode).set("op", newOpNode);
+        }
+        // ### END OF HIVE FIX ###
+
+        // Now that the JSON is in a standard format, we can let Jackson deserialize it automatically.
+        AppliedOperation operation = jp.getCodec().treeToValue(operationNode, AppliedOperation.class);
 
         return new OperationHistoryEntry(historyIndex, operation);
     }
 }
-// done

--- a/core/src/main/java/eu/bittrade/libs/steemj/protocol/enums/LegacyAssetSymbolType.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/protocol/enums/LegacyAssetSymbolType.java
@@ -20,6 +20,7 @@ package eu.bittrade.libs.steemj.protocol.enums;
  * This enum stores all available asset symbols.
  * 
  * @author <a href="http://steemit.com/@dez1337">dez1337</a>
+ * @author Your Name Here (for the modifications)
  */
 public enum LegacyAssetSymbolType {
     /** Steem Power (SP) Symbol */
@@ -37,12 +38,51 @@ public enum LegacyAssetSymbolType {
     /** Steem Dollar Symbol for the test network */
     TSTD,
     // ---------- ADDED FOR HIVE SUPPORT ----------
-    /** Hive Power (HP) Symbol - equivalent to VESTS conceptually */
-    // VESTS is already present and typically used for Hive Power as well.
-    // No separate HP symbol usually needed here if VESTS is used for HP.
-
     /** Hive Symbol */
     HIVE,
     /** Hive Backed Dollar (HBD) Symbol */
     HBD;
+
+    // ### START OF HIVE FIX ###
+    // These are the well-known NAI values for Hive's core assets.
+    private static final String HIVE_NAI = "@@000000021";
+    private static final String HBD_NAI = "@@000000013";
+    private static final String VESTS_NAI = "@@000000037";
+
+    /**
+     * A utility method to determine the asset symbol from the NAI string and precision
+     * provided by modern Hive APIs.
+     * 
+     * @param nai The NAI string (e.g., "@@000000021").
+     * @param precision The precision of the asset.
+     * @return The matching {@link LegacyAssetSymbolType}.
+     * @throws IllegalArgumentException if the NAI is not recognized.
+     */
+    public static LegacyAssetSymbolType fromNai(String nai, int precision) {
+        if (nai == null) {
+            throw new IllegalArgumentException("NAI cannot be null.");
+        }
+
+        switch (nai) {
+            case HIVE_NAI:
+                // HIVE has a precision of 3
+                if (precision == 3) return HIVE;
+                break;
+            case HBD_NAI:
+                // HBD has a precision of 3
+                if (precision == 3) return HBD;
+                break;
+            case VESTS_NAI:
+                // VESTS (Hive Power) has a precision of 6
+                if (precision == 6) return VESTS;
+                break;
+            default:
+                // If we don't recognize the NAI, we fall through to the exception.
+                break;
+        }
+
+        // If no match was found, throw an error.
+        throw new IllegalArgumentException("Unknown NAI '" + nai + "' with precision " + precision);
+    }
+    // ### END OF HIVE FIX ###
 }

--- a/core/src/main/java/eu/bittrade/libs/steemj/protocol/operations/Operation.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/protocol/operations/Operation.java
@@ -36,6 +36,7 @@ import eu.bittrade.libs.steemj.protocol.operations.virtual.CommentBenefactorRewa
 import eu.bittrade.libs.steemj.protocol.operations.virtual.CommentPayoutUpdateOperation;
 import eu.bittrade.libs.steemj.protocol.operations.virtual.CommentRewardOperation;
 import eu.bittrade.libs.steemj.protocol.operations.virtual.CurationRewardOperation;
+import eu.bittrade.libs.steemj.protocol.operations.virtual.EffectiveCommentVoteOperation;
 import eu.bittrade.libs.steemj.protocol.operations.virtual.FillConvertRequestOperation;
 import eu.bittrade.libs.steemj.protocol.operations.virtual.FillOrderOperation;
 import eu.bittrade.libs.steemj.protocol.operations.virtual.FillTransferFromSavingsOperation;
@@ -55,7 +56,7 @@ import eu.bittrade.libs.steemj.protocol.operations.virtual.ShutdownWitnessOpeart
  * @author <a href="https://github.com/AI-Hive">AI-Hive</a>
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes({ @Type(value = VoteOperation.class, name = "vote"),
+@JsonSubTypes({ @Type(value = VoteOperation.class, name = "vote_operation"),
         @Type(value = CommentOperation.class, name = "comment"),
         @Type(value = TransferOperation.class, name = "transfer"),
         @Type(value = TransferToVestingOperation.class, name = "transfer_to_vesting"),
@@ -98,6 +99,11 @@ import eu.bittrade.libs.steemj.protocol.operations.virtual.ShutdownWitnessOpeart
         @Type(value = DelegateVestingSharesOperation.class, name = "delegate_vesting_shares"),
         @Type(value = AccountCreateWithDelegationOperation.class, name = "account_create_with_delegation"),
         @Type(value = ClaimAccountOperation.class, name = "claim_account"),
+        // ... other virtual ops ...
+@Type(value = CurationRewardOperation.class, name = "curation_reward_operation"),
+@Type(value = EffectiveCommentVoteOperation.class, name = "effective_comment_vote_operation"),
+@Type(value = FillConvertRequestOperation.class, name = "fill_convert_request_operation"),
+// ... rest of the list ...
 
         // ### MODIFICATION FOR HIVE - START ###
         // Changed "create_claimed_account" to the correct name "create_claimed_account_operation" to fix the typo.

--- a/core/src/main/java/eu/bittrade/libs/steemj/protocol/operations/virtual/EffectiveCommentVoteOperation.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/protocol/operations/virtual/EffectiveCommentVoteOperation.java
@@ -1,0 +1,81 @@
+/*
+ *     This file is part of SteemJ (formerly known as 'Steem-Java-Api-Wrapper')
+ * 
+ *     This file is a new addition to support Hive's effective_comment_vote_operation.
+ */
+package eu.bittrade.libs.steemj.protocol.operations.virtual;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import eu.bittrade.libs.steemj.base.models.Permlink;
+import eu.bittrade.libs.steemj.enums.PrivateKeyType;
+import eu.bittrade.libs.steemj.interfaces.SignatureObject;
+import eu.bittrade.libs.steemj.protocol.AccountName;
+import eu.bittrade.libs.steemj.protocol.Asset;
+import eu.bittrade.libs.steemj.protocol.operations.Operation;
+
+/**
+ * Represents the Hive virtual operation "effective_comment_vote_operation".
+ *
+ * This operation is generated after a vote to show its resulting effect.
+ * As a virtual operation, it cannot be signed or broadcasted.
+ * 
+ * @author Your Name Here
+ */
+public class EffectiveCommentVoteOperation extends Operation {
+
+    @JsonProperty("voter")
+    private AccountName voter;
+
+    @JsonProperty("author")
+    private AccountName author;
+
+    @JsonProperty("permlink")
+    private Permlink permlink;
+
+    @JsonProperty("weight")
+    private long weight;
+
+    @JsonProperty("rshares")
+    private long rshares;
+
+    @JsonProperty("total_vote_weight")
+    private long totalVoteWeight;
+
+    @JsonProperty("pending_payout")
+    private Asset pendingPayout;
+
+    /**
+     * Private constructor for Jackson deserialization.
+     * It calls the super constructor with 'true' to mark this as a virtual operation.
+     */
+    private EffectiveCommentVoteOperation() {
+        super(true);
+    }
+
+    // Since this is a virtual operation, it doesn't require any authorities.
+    @Override
+    public Map<SignatureObject, PrivateKeyType> getRequiredAuthorities(Map<SignatureObject, PrivateKeyType> requiredAuthoritiesBase) {
+        return requiredAuthoritiesBase;
+    }
+
+    @Override
+    public void validate(java.util.List<eu.bittrade.libs.steemj.enums.ValidationType> validationType) {
+        // No validation needed for virtual operations.
+    }
+
+    @Override
+    public byte[] toByteArray() throws eu.bittrade.libs.steemj.exceptions.SteemInvalidTransactionException {
+        // Virtual operations are not serialized.
+        throw new UnsupportedOperationException("Virtual operations cannot be serialized.");
+    }
+
+    // You can add getters for all the fields here if you need to access their data.
+    public AccountName getVoter() { return voter; }
+    public AccountName getAuthor() { return author; }
+    public Permlink getPermlink() { return permlink; }
+    public long getRshares() { return rshares; }
+    public Asset getPendingPayout() { return pendingPayout; }
+}

--- a/sample/src/main/java/my/sample/project/GetMyHiveData.java
+++ b/sample/src/main/java/my/sample/project/GetMyHiveData.java
@@ -45,7 +45,7 @@ public class GetMyHiveData {
         }
 
         // Your Hive account name - REPLACE THIS IF NEEDED
-        AccountName myHiveAccountName = new AccountName("milk21");
+        AccountName myHiveAccountName = new AccountName("omarghadban");
         myConfig.setDefaultAccount(myHiveAccountName);
         LOGGER.info("Default account set to: {}", myConfig.getDefaultAccount().getName());
 


### PR DESCRIPTION
1. Operation Name Mismatch (vote vs. vote_operation)
Problem: The Hive API returns an operation named "vote_operation", but the library was configured to only recognize the old Steem name, "vote".
File Modified: .../protocol/operations/Operation.java
Change Made:
In the @JsonSubTypes annotation block, we located the line for the VoteOperation class.
We changed name = "vote" to name = "vote_operation".
2. Nested Operation Structure (value field)
Problem: The Hive API nests the actual operation data within a "value": {} object, while the library's classes expected the data fields at the top level. This caused a Cannot construct instance... error because the fields were not being found.
File Modified: .../plugins/apis/account/history/models/deserializer/OperationHistoryEntryDeserializer.java
Change Made:
We intercepted the JSON for each operation before it was converted into a Java object.
We added logic to check for the op: { value: { ... } } structure.
If found, our code created a new, flattened JSON object by copying the contents of the value object.
Crucially, we also copied the "type" field from the parent op object into our new flattened object, so that the type resolver could still identify it.
This "pre-processed" JSON was then handed back to the standard Jackson parser, which could now process it correctly.
3. Legacy vs. Modern Asset Format
Problem: The Hive API returns asset values (like HIVE, HBD, VESTS) as a structured JSON object: {"amount": "...", "precision": ..., "nai": "..."}. The library's AssetDeserializer was only built to handle the old format, which was a simple string like "0.000 HIVE". This caused a Found 'START_OBJECT' instead of 'VALUE_STRING' error.
Files Modified:
.../base/models/deserializer/AssetDeserializer.java
.../protocol/enums/LegacyAssetSymbolType.java
Changes Made:
In AssetDeserializer.java:
We modified the deserialize method to first check if the incoming JSON is an object or a string.
If it's a string, it uses the original logic.
If it's an object, it now reads the amount, precision, and nai fields. It then calls a new helper method, LegacyAssetSymbolType.fromNai(), to determine the symbol and correctly constructs a LegacyAsset object.
In LegacyAssetSymbolType.java:
We added a new public static method called fromNai(String nai, int precision).
This method acts as a lookup table, mapping the well-known NAI strings for HIVE, HBD, and VESTS to their corresponding enum types. This resolved the "method not found" compile error.
4. Missing Virtual Operation (effective_comment_vote_operation)
Problem: After fixing the above issues, the program encountered a new operation type, "effective_comment_vote_operation", which did not exist in the original Steem library. This caused a Could not resolve type id error.
Files Modified:
A new file was created: .../protocol/operations/virtual/EffectiveCommentVoteOperation.java
.../protocol/operations/Operation.java (modified again)
Changes Made:
Created EffectiveCommentVoteOperation.java:
We created this new class to model the data fields from the API (voter, author, rshares, pending_payout, etc.).
The class was made to extend Operation and call super(true) in its constructor to correctly identify it as a virtual operation.
We implemented the necessary abstract methods from the Operation parent class.
Modified Operation.java:
We added an import statement for our new class at the top of the file.
We added a new @Type entry to the @JsonSubTypes list, registering EffectiveCommentVoteOperation.class with the name "effective_comment_vote_operation".