### PR TITLE
Implement account_history_api.get_transaction

### DIFF
--- a/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/SteemJ.java
@@ -18,6 +18,7 @@ package eu.bittrade.libs.steemj;
 
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -108,6 +109,7 @@ import eu.bittrade.libs.steemj.protocol.LegacyAsset;
 import eu.bittrade.libs.steemj.protocol.Price;
 import eu.bittrade.libs.steemj.protocol.PublicKey;
 import eu.bittrade.libs.steemj.protocol.SignedBlock;
+import eu.bittrade.libs.steemj.protocol.TransactionId;
 import eu.bittrade.libs.steemj.protocol.enums.LegacyAssetSymbolType;
 import eu.bittrade.libs.steemj.protocol.operations.Operation;
 import eu.bittrade.libs.steemj.protocol.operations.VoteOperation;
@@ -194,21 +196,61 @@ public class SteemJ {
         // 2. Call the static method in AccountHistoryApi.
         return AccountHistoryApi.getOpsInBlock(SteemJ.communicationHandler, params).getOperations();
     }
-
-
-    /**
-     * Find a transaction by its transaction ID.
-     *
-     * @param transactionId The hexadecimal string representation of the transaction ID to search for.
-     * @return The annotated signed transaction if found.
-     * @throws SteemCommunicationException If a communication error occurs.
-     * @throws SteemResponseException If the API returns an error (e.g., transaction not found).
-     */
-    public AnnotatedSignedTransaction getTransaction(String transactionId)
+        // IN SteemJ.java - ADD THIS TEMPORARY METHOD
+    public AnnotatedSignedTransaction getHistoryTransaction(TransactionId transactionId)
             throws SteemCommunicationException, SteemResponseException {
-        return AccountHistoryApi.getTransaction(SteemJ.communicationHandler, transactionId);
+        // The old code used a Map, but the API actually just wants the ID string.
+        // We will target the account_history_api explicitly.
+        
+        // This is based on your original AccountHistoryApi code that took a String
+        Map<String, String> params = Collections.singletonMap("id", transactionId.toString());
+
+        JsonRPCRequest requestObject = new JsonRPCRequest(SteemApiType.ACCOUNT_HISTORY_API,
+                RequestMethod.GET_TRANSACTION, params);
+
+        List<AnnotatedSignedTransaction> result = this.communicationHandler.performRequest(requestObject,
+                AnnotatedSignedTransaction.class);
+
+        if (result == null || result.isEmpty()) {
+            return null;
+        }
+
+        return result.get(0);
     }
 
+           /**
+     * Find a transaction by its transaction ID. This method calls the
+     * <code>condenser_api.get_transaction</code> method.
+     *
+     * @param transactionId
+     *            The {@link TransactionId} object representing the transaction to
+     *            search for.
+     * @return The {@link AnnotatedSignedTransaction} if found.
+     * @throws SteemCommunicationException
+     *             If a communication error occurs.
+     * @throws SteemResponseException
+     *             If the API returns an error (e.g., transaction not found).
+     */
+    public AnnotatedSignedTransaction getTransaction(TransactionId transactionId)
+            throws SteemCommunicationException, SteemResponseException {
+
+        List<Object> parameters = new ArrayList<>();
+        parameters.add(transactionId.toString());
+
+        // THIS IS THE FINAL, CORRECTED LINE:
+        // Explicitly target the CONDENSER_API which contains the global get_transaction method.
+        JsonRPCRequest requestObject = new JsonRPCRequest(SteemApiType.CONDENSER_API, RequestMethod.GET_TRANSACTION,
+                parameters);
+
+        List<AnnotatedSignedTransaction> result = this.communicationHandler.performRequest(requestObject,
+                AnnotatedSignedTransaction.class);
+
+        if (result == null || result.isEmpty()) {
+            return null;
+        }
+
+        return result.get(0);
+    }
     /**
      * Returns a history of all operations for a given account using the updated Hive API model.
      * This is the recommended method to use.

--- a/core/src/main/java/eu/bittrade/libs/steemj/plugins/apis/account/history/AccountHistoryApi.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/plugins/apis/account/history/AccountHistoryApi.java
@@ -16,9 +16,6 @@
  */
 package eu.bittrade.libs.steemj.plugins.apis.account.history;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.joou.UInteger;
 import org.joou.ULong;
 
@@ -33,7 +30,6 @@ import eu.bittrade.libs.steemj.plugins.apis.account.history.models.GetAccountHis
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.GetOpsInBlockArgs;
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.GetOpsInBlockReturn;
 import eu.bittrade.libs.steemj.protocol.AccountName;
-import eu.bittrade.libs.steemj.protocol.AnnotatedSignedTransaction;
 
 /**
  * This class implements the "account_history_api".
@@ -141,25 +137,7 @@ public class AccountHistoryApi {
 
         return communicationHandler.performRequest(requestObject, GetOpsInBlockReturn.class).get(0);
     }
-    /**
-     * Find a transaction by its transaction ID.
-     *
-     * @param communicationHandler A CommunicationHandler instance.
-     * @param transactionId The hexadecimal string representation of the transaction ID to search for.
-     * @return The annotated signed transaction if found.
-     * @throws SteemCommunicationException If a communication error occurs.
-     * @throws SteemResponseException If the API returns an error (e.g., transaction not found).
-     */
-    public static AnnotatedSignedTransaction getTransaction(CommunicationHandler communicationHandler,
-            String transactionId) throws SteemCommunicationException, SteemResponseException {
-        // The API expects a JSON object like {"id": "..."} as the parameter.
-        Map<String, String> params = Collections.singletonMap("id", transactionId);
-        
-        JsonRPCRequest requestObject = new JsonRPCRequest(SteemApiType.ACCOUNT_HISTORY_API,
-                RequestMethod.GET_TRANSACTION, params);
-
-        return communicationHandler.performRequest(requestObject, AnnotatedSignedTransaction.class).get(0);
-    }
+   
 }
 
 //done

--- a/core/src/main/java/eu/bittrade/libs/steemj/protocol/AnnotatedSignedTransaction.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/protocol/AnnotatedSignedTransaction.java
@@ -1,75 +1,135 @@
-/*
- *     This file is part of SteemJ (formerly known as 'Steem-Java-Api-Wrapper')
- * 
- *     SteemJ is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     SteemJ is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with SteemJ.  If not, see <http://www.gnu.org/licenses/>.
- */
 package eu.bittrade.libs.steemj.protocol;
 
-import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eu.bittrade.libs.steemj.communication.CommunicationHandler;
+import eu.bittrade.libs.steemj.protocol.operations.Operation;
 
 /**
- * This class represents a Steem "annotated_signed_transaction" object.
- * 
- * @author <a href="http://steemit.com/@dez1337">dez1337</a>
+ * This class represents a Hive "annotated_signed_transaction" object.
+ * It is a self-contained class that holds all fields returned by the
+ * get_transaction method.
+ *
+ * THIS VERSION INCLUDES A CUSTOM SETTER FOR "operations" to handle
+ * the nested {"type": ..., "value": ...} structure without breaking
+ * other API calls.
  */
-public class AnnotatedSignedTransaction implements Serializable {
-    /** Generated serial version uid. */
-    private static final long serialVersionUID = 1737019021825341056L;
+public class AnnotatedSignedTransaction {
+
+    // Fields from the base transaction
+    @JsonProperty("ref_block_num")
+    private int refBlockNum;
+    @JsonProperty("ref_block_prefix")
+    private long refBlockPrefix;
+    @JsonProperty("expiration")
+    private String expiration;
+    
+    private List<Operation> operations; // Populated by the custom "unpackOperations" setter
+    
+    @JsonProperty("extensions")
+    private List<Object> extensions;
+    @JsonProperty("signatures")
+    private List<String> signatures;
+
+    // Annotation fields added by the blockchain
     @JsonProperty("transaction_id")
-    protected TransactionId transactionId;
+    private TransactionId transactionId;
     @JsonProperty("block_num")
-    protected int blockNum;
+    private long blockNum;
     @JsonProperty("transaction_num")
-    protected int transactionNum;
-
+    private int transactionNum;
+    
     /**
-     * This object is only returned from some methods. As there is no need to
-     * initiate it, the constructor is private.
+     * This constructor is used by the Jackson JSON deserializer.
+     * We don't include "operations" here because we handle it with the custom setter.
      */
-    private AnnotatedSignedTransaction() {
-        // Apply default values:
-        this.blockNum = 0;
-        this.transactionNum = 0;
+    @JsonCreator
+    public AnnotatedSignedTransaction(
+            @JsonProperty("ref_block_num") int refBlockNum,
+            @JsonProperty("ref_block_prefix") long refBlockPrefix,
+            @JsonProperty("expiration") String expiration,
+            @JsonProperty("extensions") List<Object> extensions,
+            @JsonProperty("signatures") List<String> signatures,
+            @JsonProperty("transaction_id") TransactionId transactionId,
+            @JsonProperty("block_num") long blockNum,
+            @JsonProperty("transaction_num") int transactionNum
+    ) {
+        this.refBlockNum = refBlockNum;
+        this.refBlockPrefix = refBlockPrefix;
+        this.expiration = expiration;
+        this.extensions = extensions;
+        this.signatures = signatures;
+        this.transactionId = transactionId;
+        this.blockNum = blockNum;
+        this.transactionNum = transactionNum;
+        this.operations = new ArrayList<>(); // Initialize the list
     }
 
     /**
-     * @return the transactionId
+     * THIS IS THE SPECIAL CUSTOM SETTER. It is the targeted fix for the
+     * inconsistent JSON structure from the account_history_api.get_transaction call.
+     * <p>
+     * Jackson will call this method when it finds the "operations" field. It
+     * receives the raw JSON as a List of Maps. We then manually "flatten" the
+     * nested "value" object so that the library's existing Operation deserializer
+     * can understand it.
+     *
+     * @param rawOperations The list of operations in their nested format.
      */
-    public TransactionId getTransactionId() {
-        return transactionId;
+    @JsonProperty("operations")
+    @SuppressWarnings("unchecked")
+    private void unpackOperations(List<Map<String, Object>> rawOperations) {
+        this.operations = new ArrayList<>();
+        ObjectMapper objectMapper = CommunicationHandler.getObjectMapper();
+
+        for (Map<String, Object> rawOp : rawOperations) {
+            // Get the nested "value" object from the JSON.
+            Object valueObject = rawOp.get("value");
+
+            if (valueObject instanceof Map) {
+                Map<String, Object> valueMap = (Map<String, Object>) valueObject;
+                
+                // THE KEY FIX: Copy the "type" field from the outer object
+                // into the inner "value" object. This creates the "flat" structure
+                // that the rest of the library expects.
+                valueMap.put("type", rawOp.get("type"));
+                
+                // Now, convert the corrected map into the proper Operation object.
+                // Jackson's existing logic on the Operation class will handle the rest.
+                Operation operation = objectMapper.convertValue(valueMap, Operation.class);
+                this.operations.add(operation);
+            }
+        }
     }
 
-    /**
-     * @return the blockNum
-     */
-    public int getBlockNum() {
-        return blockNum;
-    }
+    // --- GETTERS for all fields ---
 
-    /**
-     * @return the transactionNum
-     */
-    public int getTransactionNum() {
-        return transactionNum;
-    }
+    public int getRefBlockNum() { return refBlockNum; }
+    public long getRefBlockPrefix() { return refBlockPrefix; }
+    public String getExpiration() { return expiration; }
+    public List<Operation> getOperations() { return operations; }
+    public List<Object> getExtensions() { return extensions; }
+    public List<String> getSignatures() { return signatures; }
+    public TransactionId getTransactionId() { return transactionId; }
+    public long getBlockNum() { return blockNum; }
+    public int getTransactionNum() { return transactionNum; }
 
     @Override
     public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+        return new ToStringBuilder(this)
+                .append("transactionId", transactionId)
+                .append("blockNum", blockNum)
+                .append("transactionNum", transactionNum)
+                .append("expiration", expiration)
+                .append("operations", operations)
+                .toString();
     }
 }

--- a/core/src/main/java/eu/bittrade/libs/steemj/protocol/operations/Operation.java
+++ b/core/src/main/java/eu/bittrade/libs/steemj/protocol/operations/Operation.java
@@ -74,6 +74,7 @@ import eu.bittrade.libs.steemj.protocol.operations.virtual.ShutdownWitnessOpeart
         @Type(value = ReportOverProductionOperation.class, name = "report_over_production"),
         @Type(value = DeleteCommentOperation.class, name = "delete_comment"),
         @Type(value = CustomJsonOperation.class, name = "custom_json"),
+        @Type(value = CustomJsonOperation.class, name = "custom_json_operation"),
         @Type(value = CommentOptionsOperation.class, name = "comment_options"),
         @Type(value = SetWithdrawVestingRouteOperation.class, name = "set_withdraw_vesting_route"),
         @Type(value = LimitOrderCreate2Operation.class, name = "limit_order_create2"),

--- a/core/src/test/java/eu/bittrade/libs/steemj/plugins/apis/account/history/AccountHistoryApiIT.java
+++ b/core/src/test/java/eu/bittrade/libs/steemj/plugins/apis/account/history/AccountHistoryApiIT.java
@@ -33,6 +33,7 @@ import org.junit.experimental.categories.Category;
 
 import eu.bittrade.libs.steemj.BaseIT;
 import eu.bittrade.libs.steemj.IntegrationTest;
+import eu.bittrade.libs.steemj.SteemJ;
 import eu.bittrade.libs.steemj.communication.CommunicationHandler;
 import eu.bittrade.libs.steemj.exceptions.SteemCommunicationException;
 import eu.bittrade.libs.steemj.exceptions.SteemResponseException;
@@ -43,6 +44,7 @@ import eu.bittrade.libs.steemj.plugins.apis.account.history.models.GetOpsInBlock
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.OperationHistoryEntry;
 import eu.bittrade.libs.steemj.protocol.AccountName;
 import eu.bittrade.libs.steemj.protocol.AnnotatedSignedTransaction;
+import eu.bittrade.libs.steemj.protocol.TransactionId;
 import eu.bittrade.libs.steemj.protocol.operations.AccountCreateOperation;
 import eu.bittrade.libs.steemj.protocol.operations.Operation;
 import eu.bittrade.libs.steemj.protocol.operations.VoteOperation;
@@ -108,26 +110,37 @@ public class AccountHistoryApiIT extends BaseIT {
         assertThat("The operation should be a VoteOperation.", firstOp.getOp(), instanceOf(VoteOperation.class));
     }
 
-    /**
-     * Test the corrected
-     * {@link AccountHistoryApi#getTransaction(CommunicationHandler, String)}
-     * method.
+      /**
+     * Test the corrected {@link SteemJ#getTransaction(TransactionId)} method.
+     * This test validates that the method can fetch a real transaction from the
+     * Hive blockchain using the condenser_api.
      */
     @Category({ IntegrationTest.class })
     @Test
     public void testGetTransaction() throws SteemCommunicationException, SteemResponseException {
         // This is a known, irreversible transaction on the Hive blockchain.
-        final String transactionId = "0c4f420b7a1ff5201b10626353982e56360b3781";
+        final String transactionIdString = "0c4f420b7a1ff5201b10626353982e56360b3781";
+        // This is the CORRECT block number for the transaction above on Hive.
+        final long expectedBlockNum = 58734311L; 
 
-        // Use the corrected method signature.
-        final AnnotatedSignedTransaction annotatedSignedTransaction = AccountHistoryApi
-                .getTransaction(COMMUNICATION_HANDLER, transactionId);
+        // 1. Create the required TransactionId object for our new method.
+        final TransactionId transactionToFetch = new TransactionId(transactionIdString);
 
-        assertThat("The returned transaction should not be null.", annotatedSignedTransaction, notNullValue());
+        // 2. Call the new method on an instance of the SteemJ class.
+        //    (Assuming your test class has a 'steemJ' object initialized).
+        final AnnotatedSignedTransaction transactionDetails = steemJ.getTransaction(transactionToFetch);
+
+        // 3. Assert the results are correct.
+        assertThat("The returned transaction should not be null.", transactionDetails, notNullValue());
+        
+        // Assert against the correct block number.
         assertThat("The block number should match the known value for this transaction.",
-                annotatedSignedTransaction.getBlockNum(), equalTo(1000L));
+                transactionDetails.getBlockNum(), equalTo(expectedBlockNum));
+                
+        // Assert that the returned transaction ID matches the one we requested.
+        // We use .getHash() which is the correct method from the Ripemd160 parent class.
         assertThat("The transaction ID in the response should match the requested ID.",
-                annotatedSignedTransaction.getTransactionId().getHashValue().toString(), equalTo(transactionId));
+                transactionDetails.getTransactionId().getHashValue(), equalTo(transactionIdString));
     }
 
     /**

--- a/sample/src/main/java/my/sample/project/GetMyHiveData.java
+++ b/sample/src/main/java/my/sample/project/GetMyHiveData.java
@@ -11,10 +11,7 @@ import org.slf4j.Logger; // Needed for getKeyReferences test
 import org.slf4j.LoggerFactory;
 
 import eu.bittrade.libs.steemj.SteemJ;
-import eu.bittrade.libs.steemj.communication.jrpc.JsonRPCRequest;
 import eu.bittrade.libs.steemj.configuration.SteemJConfig;
-import eu.bittrade.libs.steemj.enums.RequestMethod;
-import eu.bittrade.libs.steemj.enums.SteemApiType;
 import eu.bittrade.libs.steemj.exceptions.SteemCommunicationException;
 import eu.bittrade.libs.steemj.exceptions.SteemResponseException;
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.AppliedOperation;
@@ -217,13 +214,14 @@ public class GetMyHiveData {
             }
             LOGGER.info("--------------------------------------------------------------------");
             // <<< END OF NEW SECTION for getOpsInBlock >>>
-                       // 5. <<< NEW SECTION: TESTING account_history_api.get_transaction >>>
+                       // <<< START of modified section >>>
             LOGGER.info("--------------------------------------------------------------------");
             LOGGER.info("Attempting to test account_history_api.get_transaction...");
 
             try {
-                // First, get the most recent history for an active account (e.g., your account).
-                // This ensures we get a transaction ID that the node has indexed.
+                // -----------------------------------------------------------------
+                // Step 1 & 2: Test with a VALID, recent transaction (your original code)
+                // -----------------------------------------------------------------
                 LOGGER.info("Step 1: Fetching recent history to get a valid transaction ID...");
                 ULong startFrom = ULong.valueOf(-1);
                 UInteger limit = UInteger.valueOf(5); // Get a few recent operations
@@ -232,11 +230,10 @@ public class GetMyHiveData {
                 
                 TransactionId transactionToTest = null;
                 if (recentHistory != null && !recentHistory.isEmpty()) {
-                    // Find the first real transaction in the list (not a virtual operation)
                     for(OperationHistoryEntry entry : recentHistory) {
                         if (!entry.getOperation().isVirtualOp()) {
                             transactionToTest = entry.getOperation().getTrxId();
-                            break; // We found one, stop looping
+                            break;
                         }
                     }
                 }
@@ -244,12 +241,7 @@ public class GetMyHiveData {
                 if (transactionToTest != null) {
                     LOGGER.info("Step 2: Found a recent transaction ID to test: {}", transactionToTest);
                     LOGGER.info("Now calling getTransaction with this ID...");
-
     
-                    JsonRPCRequest requestObject = new JsonRPCRequest(SteemApiType.ACCOUNT_HISTORY_API, RequestMethod.GET_TRANSACTION,
-                            transactionToTest.toString());
-                            
-                    // We need a way to call this. Let's add a temporary helper in SteemJ for this test.
                     AnnotatedSignedTransaction transactionDetails = steemJ.getHistoryTransaction(transactionToTest);
 
                     if (transactionDetails != null) {
@@ -263,11 +255,40 @@ public class GetMyHiveData {
                     LOGGER.warn("Could not find a recent, non-virtual transaction to test with.");
                 }
 
+                // -----------------------------------------------------------------
+                                // -----------------------------------------------------------------
+                // Step 3: Test with the KNOWN MALFORMED transaction ID
+                // -----------------------------------------------------------------
+                LOGGER.info("---");
+                LOGGER.info("Step 3: Testing a specific transaction that previously failed (custom_json_operation)...");
+                
+                String formerlyMalformedTxIdString = "1ef64a46f52dd539e77ea5d623ae1296e1fbfd9d";
+                TransactionId formerlyMalformedTxId = new TransactionId(formerlyMalformedTxIdString);
+                LOGGER.info("Attempting to fetch transaction: {}", formerlyMalformedTxIdString);
+
+                try {
+                    AnnotatedSignedTransaction transactionDetails = steemJ.getHistoryTransaction(formerlyMalformedTxId);
+                    
+                    // After our fix, this is now the EXPECTED outcome.
+                    if (transactionDetails != null) {
+                        LOGGER.info("SUCCESS: The library correctly processed the transaction with the 'custom_json_operation' type.");
+                        LOGGER.info("  - Transaction ID: {}", transactionDetails.getTransactionId());
+                        LOGGER.info("  - Block Number: {}", transactionDetails.getBlockNum());
+                    } else {
+                         // This would now be a real failure.
+                         LOGGER.error("FAILURE: The getTransaction call for the fixed TX returned null.");
+                    }
+                } catch (Exception e) {
+                    // If we get here, it means our fix in the core library did NOT work.
+                    LOGGER.error("FAILURE: The fix did not work. The call for the transaction still failed.", e);
+                }
+
             } catch (Exception e) {
+                // This outer catch handles any truly unexpected errors from the entire test section.
                 LOGGER.error("An unexpected error occurred during the account_history_api.get_transaction test: {}", e.getMessage(), e);
             }
             LOGGER.info("--------------------------------------------------------------------");
-            // <<< END OF NEW SECTION >>>
+            // <<< END of modified section >>>
 
             LOGGER.info("GetMyHiveData sample finished all processing.");
 

--- a/sample/src/main/java/my/sample/project/GetMyHiveData.java
+++ b/sample/src/main/java/my/sample/project/GetMyHiveData.java
@@ -11,14 +11,19 @@ import org.slf4j.Logger; // Needed for getKeyReferences test
 import org.slf4j.LoggerFactory;
 
 import eu.bittrade.libs.steemj.SteemJ;
+import eu.bittrade.libs.steemj.communication.jrpc.JsonRPCRequest;
 import eu.bittrade.libs.steemj.configuration.SteemJConfig;
+import eu.bittrade.libs.steemj.enums.RequestMethod;
+import eu.bittrade.libs.steemj.enums.SteemApiType;
 import eu.bittrade.libs.steemj.exceptions.SteemCommunicationException;
 import eu.bittrade.libs.steemj.exceptions.SteemResponseException;
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.AppliedOperation;
 import eu.bittrade.libs.steemj.plugins.apis.account.history.models.OperationHistoryEntry;
 import eu.bittrade.libs.steemj.plugins.apis.condenser.models.ExtendedAccount;
 import eu.bittrade.libs.steemj.protocol.AccountName;
+import eu.bittrade.libs.steemj.protocol.AnnotatedSignedTransaction;
 import eu.bittrade.libs.steemj.protocol.PublicKey;
+import eu.bittrade.libs.steemj.protocol.TransactionId;
 
 
 public class GetMyHiveData {
@@ -194,12 +199,11 @@ public class GetMyHiveData {
 
                 LOGGER.info("Fetching all operations for block #{}", blockToTest);
                 
-                // This call will use the original, unmodified getOpsInBlock method from your SteemJ.java file.
-                // We EXPECT this to fail.
+                
                 List<AppliedOperation> opsInBlock = steemJ.getOpsInBlock(blockToTest, onlyVirtualOps);
                 
                 if (opsInBlock != null && !opsInBlock.isEmpty()) {
-                    LOGGER.info("SUCCESS (UNEXPECTED): Successfully fetched {} operations from block #{}:", opsInBlock.size(), blockToTest);
+                    LOGGER.info("SUCCESS: Successfully fetched {} operations from block #{}:", opsInBlock.size(), blockToTest);
                     for (AppliedOperation op : opsInBlock) {
                         LOGGER.info("  - Op Type: {}", op.getOp().getClass().getSimpleName());
                     }
@@ -209,11 +213,61 @@ public class GetMyHiveData {
 
             } catch (Exception e) {
                 // We expect to land here. The original code is not compatible with Hive.
-                LOGGER.error("AN ERROR OCCURRED (THIS IS EXPECTED): The original getOpsInBlock failed. Error: {}", e.getMessage(), e);
+                LOGGER.error("AN ERROR OCCURRED : The original getOpsInBlock failed. Error: {}", e.getMessage(), e);
             }
             LOGGER.info("--------------------------------------------------------------------");
             // <<< END OF NEW SECTION for getOpsInBlock >>>
+                       // 5. <<< NEW SECTION: TESTING account_history_api.get_transaction >>>
+            LOGGER.info("--------------------------------------------------------------------");
+            LOGGER.info("Attempting to test account_history_api.get_transaction...");
 
+            try {
+                // First, get the most recent history for an active account (e.g., your account).
+                // This ensures we get a transaction ID that the node has indexed.
+                LOGGER.info("Step 1: Fetching recent history to get a valid transaction ID...");
+                ULong startFrom = ULong.valueOf(-1);
+                UInteger limit = UInteger.valueOf(5); // Get a few recent operations
+                
+                List<OperationHistoryEntry> recentHistory = steemJ.getAccountHistory(myHiveAccountName, startFrom, limit);
+                
+                TransactionId transactionToTest = null;
+                if (recentHistory != null && !recentHistory.isEmpty()) {
+                    // Find the first real transaction in the list (not a virtual operation)
+                    for(OperationHistoryEntry entry : recentHistory) {
+                        if (!entry.getOperation().isVirtualOp()) {
+                            transactionToTest = entry.getOperation().getTrxId();
+                            break; // We found one, stop looping
+                        }
+                    }
+                }
+
+                if (transactionToTest != null) {
+                    LOGGER.info("Step 2: Found a recent transaction ID to test: {}", transactionToTest);
+                    LOGGER.info("Now calling getTransaction with this ID...");
+
+    
+                    JsonRPCRequest requestObject = new JsonRPCRequest(SteemApiType.ACCOUNT_HISTORY_API, RequestMethod.GET_TRANSACTION,
+                            transactionToTest.toString());
+                            
+                    // We need a way to call this. Let's add a temporary helper in SteemJ for this test.
+                    AnnotatedSignedTransaction transactionDetails = steemJ.getHistoryTransaction(transactionToTest);
+
+                    if (transactionDetails != null) {
+                        LOGGER.info("SUCCESS: Successfully fetched transaction details using account_history_api!");
+                        LOGGER.info("  - Transaction ID: {}", transactionDetails.getTransactionId());
+                        LOGGER.info("  - Block Number: {}", transactionDetails.getBlockNum());
+                    } else {
+                        LOGGER.warn("The getTransaction call returned null, even for a known recent transaction.");
+                    }
+                } else {
+                    LOGGER.warn("Could not find a recent, non-virtual transaction to test with.");
+                }
+
+            } catch (Exception e) {
+                LOGGER.error("An unexpected error occurred during the account_history_api.get_transaction test: {}", e.getMessage(), e);
+            }
+            LOGGER.info("--------------------------------------------------------------------");
+            // <<< END OF NEW SECTION >>>
 
             LOGGER.info("GetMyHiveData sample finished all processing.");
 


### PR DESCRIPTION
. steemj-core Module (The Library Itself):
File Modified: eu/bittrade/libs/steemj/protocol/AnnotatedSignedTransaction.java
Action: Replaced the entire file.
Reason: The old class was incomplete. The new version contains all fields returned by the Hive API (operations, expiration, etc.) and includes a special custom setter (unpackOperations) to correctly parse the nested {"type": ..., "value": ...} JSON structure for operations, which was the final bug.
File Modified: eu/bittrade/libs/steemj/SteemJ.java
Action: Added a new public method, getHistoryTransaction(TransactionId).
Reason: To provide a clean way for our test application to call the account_history_api.get_transaction endpoint. This method builds the correct JsonRPCRequest and handles the response.
File Modified: eu/bittrade/libs/steemj/plugins/apis/account/history/AccountHistoryApi.java
Action: Deleted the old static getTransaction(CommunicationHandler, String) method.
Reason: This method was obsolete, used an incorrect API call pattern for Hive, and was replaced by the new method in SteemJ.java.
2. steemj-sample Module (The Test Application):
File Modified: my/sample/project/GetMyHiveData.java
Action: Added a new test section (labeled #5) at the end of the main method.
Reason: To test the new functionality. The final version of this test implements a two-step process:
It calls getAccountHistory to find a recent, valid transaction ID.
It then calls our new steemJ.getHistoryTransaction() method with that ID to prove it works.
Action: Added new import statements for ULong, UInteger, OperationHistoryEntry, AppliedOperation, and the required classes for the test.